### PR TITLE
Enable more TypeScript strictness settings

### DIFF
--- a/web/hydrui-client/src/api/types.ts
+++ b/web/hydrui-client/src/api/types.ts
@@ -68,10 +68,48 @@ export interface FileMetadata {
   };
 }
 
+export interface FileDomainParam {
+  file_service_key?: string;
+  file_service_keys?: string[];
+  deleted_file_service_key?: string;
+  deleted_file_service_keys?: string[];
+}
+
+export interface FilesParam {
+  file_id?: number;
+  file_ids?: number[];
+  hash?: string;
+  hashes?: string[];
+}
+
+// Search params
+export interface SearchFilesParams extends FileDomainParam {
+  tags: string[];
+  tag_service_key?: string;
+  include_current_tags?: boolean;
+  include_pending_tags?: boolean;
+  file_sort_type?: number;
+  file_sort_asc?: boolean;
+  return_file_ids?: boolean;
+  return_hashes?: boolean;
+}
+
 // Search response
 export interface SearchFilesResponse extends ApiResponse {
   file_ids: number[];
   hashes?: string[];
+}
+
+// File metadata params
+export interface FileMetadataParams extends FilesParam {
+  create_new_file_ids?: boolean;
+  only_return_identifiers?: boolean;
+  only_return_basic_information?: boolean;
+  detailed_url_information?: boolean;
+  include_blurhash?: boolean;
+  include_milliseconds?: boolean;
+  include_notes?: boolean;
+  include_services_object?: boolean;
 }
 
 // File metadata response
@@ -99,6 +137,11 @@ export interface Page {
 
 export interface PageResponse extends ApiResponse {
   pages: Page;
+}
+
+export interface PageInfoParams {
+  page_key: string;
+  simple?: boolean;
 }
 
 // Page info response - this would contain information about files in a page
@@ -130,6 +173,18 @@ export interface AddFilesRequest {
   file_ids?: number[];
   hashes?: string[];
   page_key: string;
+}
+
+// Refresh page request
+export interface RefreshPageRequest {
+  page_key: string;
+}
+
+// Tag search params
+export interface TagsSearchParams extends FileDomainParam {
+  search?: string;
+  tag_service_key?: string;
+  tag_display_type?: string;
 }
 
 // Tag types
@@ -248,8 +303,7 @@ export interface HydrusApiClient {
 
   // Search
   searchFiles: (
-    tags: string[],
-    fileServiceKey?: string,
+    params: SearchFilesParams,
     signal?: AbortSignal,
   ) => Promise<SearchFilesResponse>;
   getFileMetadata: (

--- a/web/hydrui-client/src/components/modals/AboutModal/AboutModal.tsx
+++ b/web/hydrui-client/src/components/modals/AboutModal/AboutModal.tsx
@@ -52,7 +52,7 @@ const AboutModal: React.FC<AboutModalProps> = ({ onClose }) => {
                 <div className="about-modal-section">
                   <h3 className="about-modal-section-title">Version</h3>
                   <p className="about-modal-section-text">
-                    {import.meta.env.VITE_HYDRUI_VERSION}
+                    {import.meta.env["VITE_HYDRUI_VERSION"]}
                   </p>
                 </div>
 

--- a/web/hydrui-client/src/components/widgets/FileViewer/SWFViewer.tsx
+++ b/web/hydrui-client/src/components/widgets/FileViewer/SWFViewer.tsx
@@ -61,41 +61,41 @@ export default function SWFViewer({ fileUrl, autoPlay }: SWFViewerProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    let player: PlayerElement;
-    if (containerRef.current && ruffle) {
-      player = ruffle.createPlayer();
-      containerRef.current.appendChild(player);
-      player.ruffle().load(fileUrl);
-
-      if (autoPlay) {
-        player.ruffle().resume();
-      }
-
-      player.addEventListener("loadedmetadata", (event) => {
-        if (event.currentTarget) {
-          const player = event.currentTarget as PlayerElement;
-          player.style.width = `${player.metadata.width}px`;
-          player.style.height = `${player.metadata.height}px`;
-          player.style.maxWidth = "100%";
-          player.style.maxHeight = "100%";
-        }
-      });
-
-      player.addEventListener("error", (event) => {
-        setError(event.error.message);
-      });
-
-      return () => {
-        player.style.display = "none";
-        // Ruffle suffers from race conditions when the player is added and removed quickly.
-        // A small delay makes it much less likely to happen, especially in strict mode,
-        // since strict mode will mount the component multiple times.
-        setTimeout(() => {
-          player.ruffle().suspend();
-          player.remove();
-        }, 100);
-      };
+    if (!containerRef.current || !ruffle) {
+      return;
     }
+    const player = ruffle.createPlayer();
+    containerRef.current.appendChild(player);
+    player.ruffle().load(fileUrl);
+
+    if (autoPlay) {
+      player.ruffle().resume();
+    }
+
+    player.addEventListener("loadedmetadata", (event) => {
+      if (event.currentTarget) {
+        const player = event.currentTarget as PlayerElement;
+        player.style.width = `${player.metadata.width}px`;
+        player.style.height = `${player.metadata.height}px`;
+        player.style.maxWidth = "100%";
+        player.style.maxHeight = "100%";
+      }
+    });
+
+    player.addEventListener("error", (event) => {
+      setError(event.error.message);
+    });
+
+    return () => {
+      player.style.display = "none";
+      // Ruffle suffers from race conditions when the player is added and removed quickly.
+      // A small delay makes it much less likely to happen, especially in strict mode,
+      // since strict mode will mount the component multiple times.
+      setTimeout(() => {
+        player.ruffle().suspend();
+        player.remove();
+      }, 100);
+    };
   }, [autoPlay, fileUrl]);
 
   return (

--- a/web/hydrui-client/src/components/widgets/Menu/MenuList.tsx
+++ b/web/hydrui-client/src/components/widgets/Menu/MenuList.tsx
@@ -187,6 +187,8 @@ const MenuList: React.FC<MenuListProps> = ({
       menu?.addEventListener("keydown", handleKeyDown);
       return () => menu?.removeEventListener("keydown", handleKeyDown);
     }
+
+    return;
   }, [
     items,
     hoveredItem,

--- a/web/hydrui-client/src/components/widgets/PageView/PageView.tsx
+++ b/web/hydrui-client/src/components/widgets/PageView/PageView.tsx
@@ -155,8 +155,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
       },
     );
     const results = await client.searchFiles(
-      [query],
-      undefined,
+      { tags: [query] },
       abortController?.signal,
     );
     removeToast(toast);
@@ -1072,14 +1071,15 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
   }, [isDragging]);
 
   useEffect(() => {
-    if (isDragging) {
-      window.addEventListener("mousemove", handleMouseMove);
-      window.addEventListener("mouseup", handleMouseUp);
-      return () => {
-        window.removeEventListener("mousemove", handleMouseMove);
-        window.removeEventListener("mouseup", handleMouseUp);
-      };
+    if (!isDragging) {
+      return;
     }
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
   }, [isDragging, handleMouseMove, handleMouseUp]);
 
   const isLoading =

--- a/web/hydrui-client/src/components/widgets/TagList/TagList.tsx
+++ b/web/hydrui-client/src/components/widgets/TagList/TagList.tsx
@@ -184,8 +184,7 @@ const TagList: React.FC = () => {
         },
       );
       const results = await client.searchFiles(
-        tags,
-        undefined,
+        { tags },
         abortController?.signal,
       );
       removeToast(toast);

--- a/web/hydrui-client/src/store/apiStore.ts
+++ b/web/hydrui-client/src/store/apiStore.ts
@@ -8,7 +8,7 @@ import { isServerMode } from "@/utils/serverMode";
 
 // Create client instance based on environment
 export const client =
-  typeof process !== "undefined" && process.env.NODE_ENV === "test"
+  typeof process !== "undefined" && process.env["NODE_ENV"] === "test"
     ? new MockHydrusClient()
     : new HydrusClient();
 

--- a/web/hydrui-client/src/store/searchStore.ts
+++ b/web/hydrui-client/src/store/searchStore.ts
@@ -84,7 +84,7 @@ export const useSearchStore = create<SearchState>()(
           set({ searchStatus: "loading", searchError: null });
 
           try {
-            const response = await client.searchFiles(searchTags);
+            const response = await client.searchFiles({ tags: searchTags });
             set({ searchResults: response.file_ids, searchStatus: "loaded" });
           } catch (error) {
             console.error("Search failed:", error);

--- a/web/hydrui-client/src/utils/autotag/wd.ts
+++ b/web/hydrui-client/src/utils/autotag/wd.ts
@@ -186,7 +186,7 @@ export async function preprocessImageWD(
 }
 
 function getWDTaggerTagNamespace(tagData: Record<string, string>): string {
-  switch (Number(tagData.category)) {
+  switch (Number(tagData["category"])) {
     case 1:
       return "creator";
     case 3:
@@ -206,15 +206,15 @@ function getWDTaggerTagNamespace(tagData: Record<string, string>): string {
 
 function processWDTagName(tagData: Record<string, string>): string {
   const namespace = getWDTaggerTagNamespace(tagData);
-  const name = rewriteUnderscoreTags(tagData.name);
+  const name = rewriteUnderscoreTags(tagData["name"]);
   return joinTagNamespace(name, namespace);
 }
 
 function processWDTagData(tagData: Record<string, string>): string[] {
   const tags = [];
   tags.push(processWDTagName(tagData));
-  if (tagData.ips) {
-    const ips: unknown = JSON.parse(tagData.ips);
+  if (tagData["ips"]) {
+    const ips: unknown = JSON.parse(tagData["ips"]);
     if (!Array.isArray(ips)) {
       return tags;
     }

--- a/web/hydrui-client/src/utils/psd/parser.ts
+++ b/web/hydrui-client/src/utils/psd/parser.ts
@@ -472,16 +472,16 @@ export class PSDParser {
 
       switch (channel.id) {
         case PSDChannelID.RED:
-          channels.red = channel;
+          channels["red"] = channel;
           break;
         case PSDChannelID.GREEN:
-          channels.green = channel;
+          channels["green"] = channel;
           break;
         case PSDChannelID.BLUE:
-          channels.blue = channel;
+          channels["blue"] = channel;
           break;
         case PSDChannelID.ALPHA:
-          channels.alpha = channel;
+          channels["alpha"] = channel;
           break;
         case PSDChannelID.MASK:
           if (layer.mask) {
@@ -492,7 +492,7 @@ export class PSDParser {
           break;
         case 0:
           // For grayscale, use the first channel
-          channels.gray = channel;
+          channels["gray"] = channel;
           break;
       }
     }
@@ -509,29 +509,29 @@ export class PSDParser {
 
         switch (colorMode) {
           case PSDColorMode.RGB: {
-            if (channels.red?.data) {
-              pixelData[pixelPos] = channels.red.data[pos];
+            if (channels["red"]?.data) {
+              pixelData[pixelPos] = channels["red"].data[pos];
             }
-            if (channels.green?.data) {
-              pixelData[pixelPos + 1] = channels.green.data[pos];
+            if (channels["green"]?.data) {
+              pixelData[pixelPos + 1] = channels["green"].data[pos];
             }
-            if (channels.blue?.data) {
-              pixelData[pixelPos + 2] = channels.blue.data[pos];
+            if (channels["blue"]?.data) {
+              pixelData[pixelPos + 2] = channels["blue"].data[pos];
             }
-            if (channels.alpha?.data) {
-              pixelData[pixelPos + 3] = channels.alpha.data[pos];
+            if (channels["alpha"]?.data) {
+              pixelData[pixelPos + 3] = channels["alpha"].data[pos];
             }
             break;
           }
 
           case PSDColorMode.GRAYSCALE: {
-            if (channels.gray?.data) {
-              const grayValue = channels.gray.data[pos];
+            if (channels["gray"]?.data) {
+              const grayValue = channels["gray"].data[pos];
               pixelData[pixelPos] = grayValue;
               pixelData[pixelPos + 1] = grayValue;
               pixelData[pixelPos + 2] = grayValue;
-              if (channels.alpha?.data) {
-                pixelData[pixelPos + 3] = channels.alpha.data[pos];
+              if (channels["alpha"]?.data) {
+                pixelData[pixelPos + 3] = channels["alpha"].data[pos];
               }
             }
             break;

--- a/web/hydrui-client/tsconfig.json
+++ b/web/hydrui-client/tsconfig.json
@@ -18,6 +18,9 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
 
     "baseUrl": ".",
     "paths": {

--- a/web/hydrui-util/tsconfig.json
+++ b/web/hydrui-util/tsconfig.json
@@ -15,7 +15,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Also, includes improvements for type safety in the API client, including catching a mistake where `only_return_identifiers` was incorrectly written as `only_include_identifiers`.