### PR TITLE
Improve escape key behavior in input boxes

### DIFF
--- a/web/hydrui-client/src/components/widgets/FileViewer/PDFViewer.tsx
+++ b/web/hydrui-client/src/components/widgets/FileViewer/PDFViewer.tsx
@@ -114,7 +114,9 @@ export default function PDFViewer({ fileUrl }: PDFViewerProps) {
   ) => {
     if (e.key === "Enter") {
       e.currentTarget.blur();
-    } else if (e.key === "Escape") {
+    } else if (e.key === "Escape" && isEditingScale) {
+      e.preventDefault();
+      e.stopPropagation();
       setIsEditingScale(false);
     }
   };

--- a/web/hydrui-client/src/components/widgets/MimeInput/MimeInput.tsx
+++ b/web/hydrui-client/src/components/widgets/MimeInput/MimeInput.tsx
@@ -79,8 +79,9 @@ const MimeInput: React.FC<MimeInputProps> = ({
       } else if (input.trim() !== "") {
         addMimeType(input.trim());
       }
-    } else if (e.key === "Escape") {
+    } else if (e.key === "Escape" && showSuggestions) {
       e.preventDefault();
+      e.stopPropagation();
       setShowSuggestions(false);
     }
   };

--- a/web/hydrui-client/src/components/widgets/PageView/SearchBar.tsx
+++ b/web/hydrui-client/src/components/widgets/PageView/SearchBar.tsx
@@ -103,8 +103,9 @@ export const SearchBar: React.FC = () => {
         // If input is empty, just perform the search
         performSearch();
       }
-    } else if (e.key === "Escape") {
+    } else if (e.key === "Escape" && showSuggestions) {
       e.preventDefault();
+      e.stopPropagation();
       setShowSuggestions(false);
     } else if (e.key === "Backspace") {
       if (input.length === 0 && searchTags.length > 0) {

--- a/web/hydrui-client/src/components/widgets/TagInput/TagInput.tsx
+++ b/web/hydrui-client/src/components/widgets/TagInput/TagInput.tsx
@@ -101,8 +101,9 @@ const TagInput: React.FC<TagInputProps> = ({
       } else if (input.trim() !== "") {
         addTag(input.trim());
       }
-    } else if (e.key === "Escape") {
+    } else if (e.key === "Escape" && showSuggestions) {
       e.preventDefault();
+      e.stopPropagation();
       setShowSuggestions(false);
     }
   };

--- a/web/hydrui-client/src/hooks/useShortcut.ts
+++ b/web/hydrui-client/src/hooks/useShortcut.ts
@@ -28,11 +28,15 @@ const globalKeydownHandler = (e: KeyboardEvent) => {
   // Unfortunately there doesn't appear to be a good way to ignore events that
   // were handled by native widget implementations, so we'll just disable global
   // shortcuts when the focused element is certain input fields.
-  if (e.target instanceof Element) {
+  if (e.target instanceof HTMLElement) {
     switch (e.target.tagName.toLowerCase()) {
       case "input":
       case "textarea":
       case "select":
+        if (e.key === "Escape" && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+          // If pressing escape inside of an input box, leave it.
+          e.target.blur();
+        }
         return;
     }
   }


### PR DESCRIPTION
When using keyboard navigation, input boxes temporarily disable hotkeys; this ensures that native shortcuts like Ctrl+A always take precedence over "global" hotkeys elsewhere in Hydrui. There is one case that needs particular attention, though: the escape key. Global escape key shortcuts are used to leave modals, but they're also used to dismiss autocomplete suggestions and cancel inputs. So, it's still wise to *not* handle global escape key shortcuts when the focus is on an input widget. That said, if the user presses escape and it does nothing at all, it would be useful if it "blurs" the focus. So, if you have autocomplete suggestions open inside of a modal, the first escape key press closes the autocomplete suggestions without blurring the focus. The second escape key press blurs the focus on the input box. The third escape key closes the modal.

Though minor, this greatly improves the user experience of ordinary keyboard navigation.