### PR TITLE
Allow filepreview to autoplay

### DIFF
--- a/web/hydrui-client/src/components/widgets/FilePreview/FilePreview.tsx
+++ b/web/hydrui-client/src/components/widgets/FilePreview/FilePreview.tsx
@@ -98,8 +98,6 @@ const FilePreview: React.FC = () => {
           fileId={activeFileId}
           fileData={fileData}
           autoActivate={false}
-          autoPlay={false}
-          loop={false}
           isPreview={true}
         />
 


### PR DESCRIPTION
There is already a mechanism that prevents videos and other media from being automatically previewed in the sidebar, so it is superfluous to also disable autoplay in the preview on top of that.

Closes #10.