### PR TITLE
Make sidebar+tags list resizable

### DIFF
--- a/web/hydrui-client/src/components/screens/MainScreen/MainScreen.tsx
+++ b/web/hydrui-client/src/components/screens/MainScreen/MainScreen.tsx
@@ -3,7 +3,7 @@ import {
   Cog6ToothIcon,
   InformationCircleIcon,
 } from "@heroicons/react/24/outline";
-import { useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 import AboutModal from "@/components/modals/AboutModal/AboutModal";
 import DemoModal from "@/components/modals/DemoModal/DemoModal";
@@ -15,19 +15,124 @@ import Sidebar from "@/components/widgets/Sidebar/Sidebar";
 import StatusBar from "@/components/widgets/StatusBar/StatusBar";
 import TabView from "@/components/widgets/TabView/TabView";
 import ToastContainer from "@/components/widgets/Toast/ToastContainer";
-import { useApiStore } from "@/store/apiStore";
+import { useApiActions } from "@/store/apiStore";
 import { MenuBarMenu } from "@/store/contextMenuStore";
+import { useUIStateActions, useUIStateStore } from "@/store/uiStateStore";
 import { isDemoMode, isServerMode } from "@/utils/modes";
 
 import "./index.css";
 
+const SIDEBAR_MIN = 150;
+
 const MainScreen = () => {
-  const {
-    actions: { setCredentials, setAuthenticated },
-  } = useApiStore();
+  const { setCredentials, setAuthenticated } = useApiActions();
+  const { setSidebarHidden, setSidebarWidthPercent } = useUIStateActions();
   const [showSettingsModal, setShowSettingsModal] = useState(false);
   const [showAboutModal, setShowAboutModal] = useState(false);
   const [showDemoModal, setShowDemoModal] = useState(isDemoMode);
+  const [sidebarWidth, setSidebarWidth] = useState({
+    hidden: useUIStateStore.getState().sidebarHidden,
+    percent: useUIStateStore.getState().sidebarWidthPercent,
+    pixels: 0,
+    lastX: -1,
+  });
+  setSidebarHidden(sidebarWidth.hidden);
+  setSidebarWidthPercent(sidebarWidth.percent);
+  const mainRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseMove = useCallback((event: MouseEvent) => {
+    setSidebarWidth((current) => {
+      if (!mainRef.current) {
+        return current;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      const movementX = event.pageX - current.lastX;
+      if (current.hidden) {
+        const clientLeft = mainRef.current.getBoundingClientRect().left;
+        const pixels = event.pageX - clientLeft - 5;
+        if (pixels > SIDEBAR_MIN) {
+          return {
+            ...current,
+            hidden: false,
+            percent: (pixels / mainRef.current.clientWidth) * 100,
+            pixels,
+            lastX: event.pageX,
+          };
+        } else {
+          return current;
+        }
+      } else {
+        const pixels = current.pixels + movementX;
+        if (pixels < SIDEBAR_MIN) {
+          return {
+            ...current,
+            hidden: true,
+            lastX: event.pageX,
+          };
+        } else {
+          return {
+            ...current,
+            percent: (pixels / mainRef.current.clientWidth) * 100,
+            pixels,
+            lastX: event.pageX,
+          };
+        }
+      }
+    });
+  }, []);
+  const handleMouseUp = useCallback(() => {
+    window.removeEventListener("mousemove", handleMouseMove);
+    window.removeEventListener("mouseup", handleMouseUp);
+  }, [handleMouseMove]);
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setSidebarWidth((current) => ({ ...current, lastX: event.pageX }));
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    },
+    [handleMouseMove, handleMouseUp],
+  );
+  const handleDoubleClick = useCallback(() => {
+    setSidebarWidth((value) => ({ ...value, hidden: !value.hidden }));
+  }, []);
+
+  useLayoutEffect(() => {
+    const adjustSidebarWidth = () => {
+      setSidebarWidth((current) => {
+        if (!mainRef.current) {
+          return current;
+        }
+        const pixels = (current.percent * mainRef.current.clientWidth) / 100;
+        return {
+          ...current,
+          pixels: pixels < SIDEBAR_MIN ? SIDEBAR_MIN : pixels,
+        };
+      });
+    };
+
+    adjustSidebarWidth();
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(adjustSidebarWidth);
+      if (mainRef.current) {
+        resizeObserver.observe(mainRef.current);
+      }
+    } else {
+      window.addEventListener("resize", adjustSidebarWidth);
+    }
+
+    return () => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      } else {
+        window.removeEventListener("resize", adjustSidebarWidth);
+      }
+    };
+  }, []);
 
   const menus: MenuBarMenu[] = [
     {
@@ -73,15 +178,32 @@ const MainScreen = () => {
     },
   ];
 
-  // Otherwise, show the main application
   return (
-    <div className="main-screen">
+    <div className="main-screen" ref={mainRef}>
       <MenuBar menus={menus} />
       <div className="main-screen-content">
-        <div className="main-screen-sidebar">
-          <Sidebar />
+        {sidebarWidth.hidden ? undefined : (
+          <div
+            className="main-screen-sidebar"
+            style={{ width: sidebarWidth.pixels || `${sidebarWidth.percent}%` }}
+          >
+            <Sidebar />
+          </div>
+        )}
+        <div className="main-screen-divider">
+          <svg
+            width="10"
+            height="100%"
+            viewBox="0 0 10 20"
+            className="main-screen-divider-handle"
+            onMouseDown={handleMouseDown}
+            onDoubleClick={handleDoubleClick}
+          >
+            <circle cx="5" cy="2" r="2" fill="currentColor" opacity="0.4" />
+            <circle cx="5" cy="8" r="2" fill="currentColor" opacity="0.4" />
+            <circle cx="5" cy="14" r="2" fill="currentColor" opacity="0.4" />
+          </svg>
         </div>
-
         <div className="main-screen-tab-view">
           <TabView />
         </div>

--- a/web/hydrui-client/src/components/screens/MainScreen/index.css
+++ b/web/hydrui-client/src/components/screens/MainScreen/index.css
@@ -13,9 +13,18 @@
 }
 
 .main-screen-sidebar {
-  width: 25%;
-  border-right: 1px solid var(--color-gray-700);
   overflow-y: auto;
+}
+
+.main-screen-divider {
+  width: 12px;
+  border-left: 1px solid var(--color-gray-700);
+  border-right: 1px solid var(--color-gray-700);
+  cursor: ew-resize;
+}
+
+.main-screen-divider:hover {
+  background-color: var(--color-gray-700);
 }
 
 .main-screen-tab-view {

--- a/web/hydrui-client/src/components/widgets/FilePreview/index.css
+++ b/web/hydrui-client/src/components/widgets/FilePreview/index.css
@@ -1,9 +1,9 @@
 .file-preview-container {
-  height: 50%;
   display: flex;
   flex-direction: column;
   padding: 0.5rem;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: scroll;
 }
 
 .file-preview-loading {
@@ -39,6 +39,7 @@
   border-radius: var(--radius-sm);
   overflow: hidden;
   position: relative;
+  min-height: 100px;
 }
 
 .file-preview-error-overlay {

--- a/web/hydrui-client/src/components/widgets/Sidebar/Sidebar.tsx
+++ b/web/hydrui-client/src/components/widgets/Sidebar/Sidebar.tsx
@@ -1,18 +1,184 @@
-import React from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 import FilePreview from "@/components/widgets/FilePreview/FilePreview";
 import TagList from "@/components/widgets/TagList/TagList";
+import { useUIStateActions, useUIStateStore } from "@/store/uiStateStore";
 
 import "./index.css";
 
-const Sidebar: React.FC = () => {
+const TAGS_MIN = 100;
+const PREVIEW_MIN = 100;
+
+function Sidebar() {
+  const { setTagListHidden, setPreviewHidden, setTagListHeightPercent } =
+    useUIStateActions();
+  const [tagsHeight, setTagsHeight] = useState({
+    tagsHidden: useUIStateStore.getState().tagListHidden,
+    previewHidden: useUIStateStore.getState().previewHidden,
+    percent: useUIStateStore.getState().tagListHeightPercent,
+    pixels: 0,
+    lastY: -1,
+  });
+  setTagListHidden(tagsHeight.tagsHidden);
+  setPreviewHidden(tagsHeight.previewHidden);
+  setTagListHeightPercent(tagsHeight.percent);
+  const mainRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseMove = useCallback((event: MouseEvent) => {
+    setTagsHeight((current) => {
+      if (!mainRef.current) {
+        return current;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      const movementY = event.pageY - current.lastY;
+      const clientTop = mainRef.current.getBoundingClientRect().top;
+      if (current.tagsHidden) {
+        const pixels = event.pageY - clientTop - 5;
+        if (pixels > TAGS_MIN) {
+          return {
+            ...current,
+            tagsHidden: false,
+            percent: (pixels / mainRef.current.clientHeight) * 100,
+            pixels,
+            lastY: event.pageY,
+          };
+        } else {
+          return current;
+        }
+      } else if (current.previewHidden) {
+        const pixels = event.pageY - clientTop - 5;
+        if (mainRef.current.clientHeight - pixels - 12 > PREVIEW_MIN) {
+          return {
+            ...current,
+            previewHidden: false,
+            percent: (pixels / mainRef.current.clientHeight) * 100,
+            pixels,
+            lastY: event.pageY,
+          };
+        } else {
+          return current;
+        }
+      } else {
+        const pixels = current.pixels + movementY;
+        if (pixels < TAGS_MIN) {
+          return {
+            ...current,
+            tagsHidden: true,
+            previewHidden: false,
+            lastY: event.pageY,
+          };
+        } else if (mainRef.current.clientHeight - pixels - 12 < PREVIEW_MIN) {
+          return {
+            ...current,
+            tagsHidden: false,
+            previewHidden: true,
+            pixels: 0,
+            percent: 100,
+            lastY: event.pageY,
+          };
+        } else {
+          return {
+            ...current,
+            previewHidden: false,
+            percent: (pixels / mainRef.current.clientHeight) * 100,
+            pixels,
+            lastY: event.pageY,
+          };
+        }
+      }
+    });
+  }, []);
+  const handleMouseUp = useCallback(() => {
+    window.removeEventListener("mousemove", handleMouseMove);
+    window.removeEventListener("mouseup", handleMouseUp);
+  }, [handleMouseMove]);
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setTagsHeight((current) => ({ ...current, lastY: event.pageY }));
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    },
+    [handleMouseMove, handleMouseUp],
+  );
+  const handleDoubleClick = useCallback(() => {
+    setTagsHeight((value) => ({ ...value, tagsHidden: !value.tagsHidden }));
+  }, []);
+
+  useLayoutEffect(() => {
+    const adjustTagsHeight = () => {
+      setTagsHeight((current) => {
+        if (!mainRef.current) {
+          return current;
+        }
+        const pixels = (current.percent * mainRef.current.clientHeight) / 100;
+        return {
+          ...current,
+          pixels: pixels < TAGS_MIN ? TAGS_MIN : pixels,
+        };
+      });
+    };
+
+    adjustTagsHeight();
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(adjustTagsHeight);
+      if (mainRef.current) {
+        resizeObserver.observe(mainRef.current);
+      }
+    } else {
+      window.addEventListener("resize", adjustTagsHeight);
+    }
+
+    return () => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      } else {
+        window.removeEventListener("resize", adjustTagsHeight);
+      }
+    };
+  }, []);
+
   return (
-    <div className="sidebar-container">
-      <TagList />
-      <div className="sidebar-divider"></div>
-      <FilePreview />
+    <div className="sidebar-container" ref={mainRef}>
+      {tagsHeight.tagsHidden ? undefined : (
+        <TagList
+          style={
+            tagsHeight.previewHidden
+              ? { height: "calc(100% - 12px)" }
+              : { height: tagsHeight.pixels || `${tagsHeight.percent}%` }
+          }
+        />
+      )}
+      <div
+        className="sidebar-divider"
+        style={
+          tagsHeight.tagsHidden
+            ? { borderTop: "none" }
+            : tagsHeight.previewHidden
+              ? { borderBottom: "none" }
+              : undefined
+        }
+      >
+        <svg
+          height="10"
+          width="100%"
+          viewBox="0 0 20 10"
+          className="sidebar-divider-handle"
+          onMouseDown={handleMouseDown}
+          onDoubleClick={handleDoubleClick}
+        >
+          <circle cx="2" cy="5" r="2" fill="currentColor" opacity="0.4" />
+          <circle cx="8" cy="5" r="2" fill="currentColor" opacity="0.4" />
+          <circle cx="14" cy="5" r="2" fill="currentColor" opacity="0.4" />
+        </svg>
+      </div>
+      {tagsHeight.previewHidden ? undefined : <FilePreview />}
     </div>
   );
-};
+}
 
 export default Sidebar;

--- a/web/hydrui-client/src/components/widgets/Sidebar/index.css
+++ b/web/hydrui-client/src/components/widgets/Sidebar/index.css
@@ -5,7 +5,12 @@
 }
 
 .sidebar-divider {
+  height: 12px;
   border-top: 1px solid var(--color-gray-700);
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-gray-700);
+  cursor: ns-resize;
+}
+
+.sidebar-divider:hover {
+  background-color: var(--color-gray-700);
 }

--- a/web/hydrui-client/src/components/widgets/TagList/TagList.tsx
+++ b/web/hydrui-client/src/components/widgets/TagList/TagList.tsx
@@ -1,6 +1,7 @@
 import { PlusIcon } from "@heroicons/react/24/solid";
 import { MinusIcon } from "@heroicons/react/24/solid";
 import React, {
+  CSSProperties,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -93,7 +94,7 @@ async function getTagSummary(
 }
 
 // TagList component to display tags of selected files or current view
-const TagList: React.FC = () => {
+function TagList({ style }: { style?: CSSProperties | undefined }) {
   const { showContextMenu } = useContextMenu();
   const selectedFilesByPage = usePageStore(
     (state) => state.selectedFilesByPage,
@@ -511,7 +512,7 @@ const TagList: React.FC = () => {
   }, [quickEdit, tagServices, activeServiceKey, setLastActiveTagService]);
 
   return (
-    <div className="tag-list-container">
+    <div className="tag-list-container" style={style}>
       <div className="tag-list-header">
         <h3 className="tag-list-title">Tags</h3>
         <label>
@@ -607,7 +608,7 @@ const TagList: React.FC = () => {
       )}
     </div>
   );
-};
+}
 
 interface TagListEntryProps {
   tag: string;

--- a/web/hydrui-client/src/components/widgets/TagList/index.css
+++ b/web/hydrui-client/src/components/widgets/TagList/index.css
@@ -1,8 +1,8 @@
 .tag-list-container {
-  height: 50%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 .tag-list-header {

--- a/web/hydrui-client/src/file/image/ImageViewer.tsx
+++ b/web/hydrui-client/src/file/image/ImageViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { FileMetadata } from "@/api/types";
 
@@ -207,6 +207,8 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
 
     // Only initiate drag with left mouse button
     if (e.button !== 0) return;
+
+    e.preventDefault();
 
     setIsDragging(true);
     setDragStart({
@@ -586,6 +588,32 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
       setPinchInfo(null);
     }
   };
+
+  useLayoutEffect(() => {
+    const recenterImage = () => {
+      if (fileData.width && fileData.height) {
+        centerImageWithSize(fileData.width, fileData.height);
+      }
+    };
+    recenterImage();
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(recenterImage);
+      if (containerRef.current) {
+        resizeObserver.observe(containerRef.current);
+      }
+    } else {
+      window.addEventListener("resize", recenterImage);
+    }
+
+    return () => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      } else {
+        window.removeEventListener("resize", recenterImage);
+      }
+    };
+  }, [fileData.height, fileData.width]);
 
   return (
     <>

--- a/web/hydrui-client/src/store/uiStateStore.ts
+++ b/web/hydrui-client/src/store/uiStateStore.ts
@@ -14,12 +14,24 @@ interface UIState {
   // Autotag threshold
   autotagThreshold: number;
 
+  // Sidebar positioning
+  sidebarWidthPercent: number;
+  sidebarHidden: boolean;
+  tagListHeightPercent: number;
+  tagListHidden: boolean;
+  previewHidden: boolean;
+
   actions: {
     setLastActiveTagService: (serviceKey: string | null) => void;
     setScrollPosition: (pageKey: string, position: number) => void;
     getScrollPosition: (pageKey: string) => number;
     setAutotagModel: (model: string) => void;
     setAutotagThreshold: (threshold: number) => void;
+    setSidebarWidthPercent: (value: number) => void;
+    setSidebarHidden: (value: boolean) => void;
+    setTagListHeightPercent: (value: number) => void;
+    setTagListHidden: (value: boolean) => void;
+    setPreviewHidden: (value: boolean) => void;
   };
 }
 
@@ -35,6 +47,11 @@ export const useUIStateStore = create<UIState>()(
       scrollLocks: {},
       autotagModel: "",
       autotagThreshold: 0.85,
+      sidebarWidthPercent: 25,
+      sidebarHidden: false,
+      tagListHeightPercent: 50,
+      tagListHidden: false,
+      previewHidden: false,
 
       // Actions
       actions: {
@@ -58,6 +75,26 @@ export const useUIStateStore = create<UIState>()(
         setAutotagThreshold(threshold: number) {
           set({ autotagThreshold: threshold });
         },
+
+        setSidebarWidthPercent(value: number) {
+          set({ sidebarWidthPercent: value });
+        },
+
+        setSidebarHidden(value: boolean) {
+          set({ sidebarHidden: value });
+        },
+
+        setTagListHeightPercent(value: number) {
+          set({ tagListHeightPercent: value });
+        },
+
+        setTagListHidden(value: boolean) {
+          set({ tagListHidden: value });
+        },
+
+        setPreviewHidden(value: boolean) {
+          set({ previewHidden: value });
+        },
       },
     }),
     {
@@ -68,6 +105,11 @@ export const useUIStateStore = create<UIState>()(
         scrollPositions: state.scrollPositions,
         autotagModel: state.autotagModel,
         autotagThreshold: state.autotagThreshold,
+        sidebarWidthPercent: state.sidebarWidthPercent,
+        sidebarHidden: state.sidebarHidden,
+        tagListHeightPercent: state.tagListHeightPercent,
+        tagListHidden: state.tagListHidden,
+        previewHidden: state.previewHidden,
       }),
     },
   ),


### PR DESCRIPTION
- Sidebar can be resized. When the window is resized, the sidebar will retain its percentage width.
- Sidebar can be hidden.
- Sidebar width percent and hidden state is saved.
- Tags list can be resized. When the window is resized, the tags list will retain its percentage height.
- Tags list or preview window can be hidden.
- Tags list height percent, tags list hidden state and preview hidden state will be saved.

Closes #11 