### PR TITLE
Use crossorigin=anonymous for thumbnails

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771008912,
-        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {

--- a/web/hydrui-client/src/components/widgets/PageView/Thumbnail.tsx
+++ b/web/hydrui-client/src/components/widgets/PageView/Thumbnail.tsx
@@ -39,6 +39,7 @@ export const Thumbnail: React.FC<ThumbnailProps> = React.memo(
                 setIsLoading(false);
               }
             }}
+            crossOrigin="anonymous"
           />
 
           {/* Loading overlay */}


### PR DESCRIPTION
This might make more sense, but needs a bit of testing probably. We're already using this for other cases because we kind of have to.