### PR TITLE
Usability improvements for selections

### DIFF
--- a/web/hydrui-client/src/components/widgets/PageView/PageView.tsx
+++ b/web/hydrui-client/src/components/widgets/PageView/PageView.tsx
@@ -5,6 +5,8 @@ import {
   ArrowTopRightOnSquareIcon,
   ArrowUpTrayIcon,
   ArrowUturnDownIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
   DocumentIcon,
   ExclamationCircleIcon,
   LinkIcon,
@@ -57,11 +59,19 @@ import { isServerMode } from "@/utils/modes";
 import { PageSearchBar } from "./PageSearchBar";
 import { Thumbnail } from "./Thumbnail";
 import "./index.css";
+import {
+  createSelectionIndex,
+  getSelectionOverflow,
+  getSelectionScrollTarget,
+  getViewerExitSelection,
+  selectionIncludesIndex,
+} from "./selectionNavigation";
 
 // Defines the amount of "scroll slack" used to compute item visibility for the
 // render view. This combats scroll jank at the cost of making rendering more
 // expensive.
 const SCROLL_SLACK = 200;
+const GAP_SIZE = 16;
 
 // Referentially stable empty array.
 const EMPTY_ARRAY: never[] = [];
@@ -156,9 +166,32 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
     bottomRows: 0,
     viewHeight: 0,
   });
+  const [selectionOverflow, setSelectionOverflow] = useState({
+    above: 0,
+    below: 0,
+  });
+  const pendingViewerSelectionRef = useRef<number | null>(null);
 
   const selectedFiles = selectedFilesByPage[pageKey] || EMPTY_ARRAY;
   const activeFileId = activeFileByPage[pageKey];
+  const selectionIndex = useMemo(
+    () =>
+      createSelectionIndex(
+        selectedFiles,
+        fileIdToIndex,
+        selectedFiles === fileIds,
+      ),
+    [fileIdToIndex, fileIds, selectedFiles],
+  );
+  const isFileSelected = useCallback(
+    (fileId: number) => {
+      const index = fileIdToIndex.get(fileId);
+      return (
+        index !== undefined && selectionIncludesIndex(selectionIndex, index)
+      );
+    },
+    [fileIdToIndex, selectionIndex],
+  );
 
   const archiveFilesById = useCallback(
     async (files: number[]) => {
@@ -209,7 +242,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
 
   const selectAllFiles = useCallback(() => {
     const { fileIds } = usePageStore.getState();
-    setSelectedFiles(pageKey, [...fileIds]);
+    setSelectedFiles(pageKey, fileIds);
   }, [pageKey, setSelectedFiles]);
 
   const findSimilarFiles = async (distance: number) => {
@@ -218,9 +251,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
       ? (await metadataLoadController.demandFetchMetadata(selectedFiles)).map(
           (f) => f.hash,
         )
-      : loadedFiles
-          .filter((f) => selectedFiles.includes(f.file_id))
-          .map((f) => f.hash);
+      : loadedFiles.filter((f) => isFileSelected(f.file_id)).map((f) => f.hash);
     const query =
       "system:similar to " +
       selectedFileHashes.join(", ") +
@@ -340,10 +371,64 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
     ...viewMenuItems,
   ];
 
-  const GAP_SIZE = 16;
-
   // Calculate grid dimensions based on container width
   const [gridDimensions, setGridDimensions] = useState({ cols: 4, rows: 1 });
+
+  const updateSelectionOverflow = useCallback(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+
+    const nextOverflow = getSelectionOverflow({
+      selectionIndex,
+      columns: gridDimensions.cols,
+      itemSize: thumbnailSize,
+      gapSize: GAP_SIZE,
+      scrollTop: grid.scrollTop,
+      viewportHeight: grid.clientHeight,
+    });
+    setSelectionOverflow((currentOverflow) =>
+      currentOverflow.above === nextOverflow.above &&
+      currentOverflow.below === nextOverflow.below
+        ? currentOverflow
+        : nextOverflow,
+    );
+  }, [gridDimensions.cols, selectionIndex, thumbnailSize]);
+
+  const scrollToSelectionEdge = useCallback(
+    (edge: "top" | "bottom") => {
+      const grid = gridRef.current;
+      if (!grid) return;
+
+      const target = getSelectionScrollTarget(
+        edge,
+        {
+          selectionIndex,
+          columns: gridDimensions.cols,
+          itemSize: thumbnailSize,
+          gapSize: GAP_SIZE,
+        },
+        grid.clientHeight,
+      );
+      if (target === null) return;
+
+      const scrollTop = Math.min(
+        target,
+        Math.max(0, grid.scrollHeight - grid.clientHeight),
+      );
+      if (typeof grid.scrollTo === "function") {
+        grid.scrollTo({ top: scrollTop, behavior: "smooth" });
+      } else {
+        grid.scrollTop = scrollTop;
+        updateSelectionOverflow();
+      }
+    },
+    [
+      gridDimensions.cols,
+      selectionIndex,
+      thumbnailSize,
+      updateSelectionOverflow,
+    ],
+  );
 
   const handleRecalculateRenderView = useCallback(
     (
@@ -387,12 +472,23 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
       const firstIndex = firstRow * cols;
       const lastIndex = Math.min((lastRow + 1) * cols, filesLength);
       const viewHeight = rows * (thumbnailSize + GAP_SIZE) + GAP_SIZE;
-      setRenderView({
-        firstIndex,
-        lastIndex,
-        topRows,
-        bottomRows,
-        viewHeight,
+      setRenderView((currentView) => {
+        if (
+          currentView.firstIndex === firstIndex &&
+          currentView.lastIndex === lastIndex &&
+          currentView.topRows === topRows &&
+          currentView.bottomRows === bottomRows &&
+          currentView.viewHeight === viewHeight
+        ) {
+          return currentView;
+        }
+        return {
+          firstIndex,
+          lastIndex,
+          topRows,
+          bottomRows,
+          viewHeight,
+        };
       });
     },
     [useVirtualViewport],
@@ -402,7 +498,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
     const calculateDimensions = () => {
       if (!gridRef.current) return;
       const width = gridRef.current.clientWidth - 32; // Account for container padding
-      const cols = Math.floor(width / (thumbnailSize + GAP_SIZE));
+      const cols = Math.max(1, Math.floor(width / (thumbnailSize + GAP_SIZE)));
       const rows = Math.ceil(fileIds.length / cols);
       setGridDimensions({ cols, rows });
       handleRecalculateRenderView(
@@ -410,6 +506,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
         { cols, rows },
         thumbnailSize,
       );
+      updateSelectionOverflow();
     };
 
     calculateDimensions();
@@ -432,7 +529,16 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
         window.removeEventListener("resize", calculateDimensions);
       }
     };
-  }, [fileIds.length, handleRecalculateRenderView, thumbnailSize]);
+  }, [
+    fileIds.length,
+    handleRecalculateRenderView,
+    thumbnailSize,
+    updateSelectionOverflow,
+  ]);
+
+  useLayoutEffect(() => {
+    updateSelectionOverflow();
+  }, [updateSelectionOverflow, renderView.viewHeight]);
 
   // Reprioritize metadata loading when scrolling w/ debounce
   useEffect(() => {
@@ -605,10 +711,11 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
 
     if (event.ctrlKey || event.metaKey) {
       // Toggle selection with Ctrl/Cmd
-      if (selectedFiles.includes(fileId)) {
+      if (isFileSelected(fileId)) {
         setSelectedFiles(
           pageKey,
           selectedFiles.filter((id) => id !== fileId),
+          { offerRestore: false },
         );
         if (activeFileId === fileId) {
           setActiveFileId(pageKey, null);
@@ -642,6 +749,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
     // Double click - open modal
     const fileIndex = fileIdToIndex.get(fileId);
     if (fileIndex !== undefined) {
+      pendingViewerSelectionRef.current = null;
       setModalIndex(fileIndex);
     }
     return;
@@ -657,9 +765,10 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
     event.stopPropagation();
 
     let selectedFiles = selectedFilesByPage[pageKey] || [];
+    const fileWasSelected = isFileSelected(fileId);
 
     // If the file isn't in the current selection, select only it
-    if (!selectedFiles.includes(fileId)) {
+    if (!fileWasSelected) {
       setSelectedFiles(pageKey, [fileId]);
       selectedFiles = [fileId];
     }
@@ -668,7 +777,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
 
     // Get the selected files' metadata
     const selectedFileMetadata = loadedFiles.filter((f) =>
-      selectedFiles.includes(f.file_id),
+      fileWasSelected ? isFileSelected(f.file_id) : f.file_id === fileId,
     );
 
     // Show context menu
@@ -737,9 +846,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
                       selectedFiles,
                     )
                   ).map((f) => f.hash)
-                : loadedFiles
-                    .filter((f) => selectedFiles.includes(f.file_id))
-                    .map((f) => f.hash);
+                : selectedFileMetadata.map((f) => f.hash);
               const relationships = await client.getFileRelationships({
                 hashes,
               });
@@ -1221,8 +1328,27 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
 
   // Modal navigation handlers
   const handleModalClose = () => {
+    pendingViewerSelectionRef.current = fileIds[modalIndex] ?? null;
     setModalIndex(-1);
   };
+
+  useEffect(() => {
+    if (modalIndex !== -1) return;
+    const lastViewedFileId = pendingViewerSelectionRef.current;
+    pendingViewerSelectionRef.current = null;
+    if (lastViewedFileId === null) return;
+
+    const currentSelection =
+      usePageStore.getState().selectedFilesByPage[pageKey] || [];
+    const viewerExitSelection = getViewerExitSelection(
+      currentSelection,
+      lastViewedFileId,
+    );
+    if (!viewerExitSelection) return;
+
+    setSelectedFiles(pageKey, viewerExitSelection);
+    setActiveFileId(pageKey, lastViewedFileId);
+  }, [modalIndex, pageKey, setActiveFileId, setSelectedFiles]);
 
   const modalHasPrevious = modalIndex > 0;
   const modalHasNext = modalIndex < fileIds.length - 1;
@@ -1284,10 +1410,11 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
         event.preventDefault();
         if (event.ctrlKey || event.metaKey) {
           // Toggle selection with Ctrl/Cmd
-          if (selectedFiles.includes(fileId)) {
+          if (selectionIncludesIndex(selectionIndex, currentIndex)) {
             setSelectedFiles(
               pageKey,
               selectedFiles.filter((id) => id !== fileId),
+              { offerRestore: false },
             );
             if (activeFileId === fileId) {
               setActiveFileId(pageKey, null);
@@ -1481,7 +1608,7 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
         (selectedFilesByPage[pageKey] &&
           selectedFilesByPage[pageKey].length !== 0)
       ) {
-        setSelectedFiles(pageKey, fileIdsToSelect);
+        setSelectedFiles(pageKey, fileIdsToSelect, { offerRestore: false });
       }
 
       // Update active file
@@ -1552,144 +1679,182 @@ const PageViewImpl: React.FC<PageViewProps> = ({ pageKey }) => {
           <PageSearchBar />
         </div>
       )}
-      <ScrollView
-        ref={gridRef}
-        className="files-grid"
-        style={{
-          gridTemplateColumns: `repeat(${gridDimensions.cols}, minmax(${thumbnailSize}px, 1fr))`,
-          gap: `${GAP_SIZE}px`,
-          cursor: isDragging ? "crosshair" : undefined,
-        }}
-        onMouseDown={handleMouseDown}
-        onContextMenu={handleViewContextMenu}
-        onScroll={() =>
-          handleRecalculateRenderView(
-            fileIds.length,
-            gridDimensions,
-            thumbnailSize,
-          )
-        }
-        loaded={fileIds.length !== 0 && renderView.lastIndex !== 0}
-      >
-        {/* Selection rectangle */}
-        {isDragging && dragStart && dragEnd && (
-          <div
-            className="page-selection-rectangle"
-            style={{
-              left: Math.min(dragStart.x, dragEnd.x),
-              top: Math.min(dragStart.y, dragEnd.y),
-              width: Math.abs(dragEnd.x - dragStart.x),
-              height: Math.abs(dragEnd.y - dragStart.y),
-            }}
-          />
-        )}
+      <div className="files-grid-viewport">
+        <ScrollView
+          ref={gridRef}
+          className="files-grid"
+          style={{
+            gridTemplateColumns: `repeat(${gridDimensions.cols}, minmax(${thumbnailSize}px, 1fr))`,
+            gap: `${GAP_SIZE}px`,
+            cursor: isDragging ? "crosshair" : undefined,
+          }}
+          onMouseDown={handleMouseDown}
+          onContextMenu={handleViewContextMenu}
+          onScroll={() => {
+            handleRecalculateRenderView(
+              fileIds.length,
+              gridDimensions,
+              thumbnailSize,
+            );
+            updateSelectionOverflow();
+          }}
+          loaded={fileIds.length !== 0 && renderView.lastIndex !== 0}
+        >
+          {/* Selection rectangle */}
+          {isDragging && dragStart && dragEnd && (
+            <div
+              className="page-selection-rectangle"
+              style={{
+                left: Math.min(dragStart.x, dragEnd.x),
+                top: Math.min(dragStart.y, dragEnd.y),
+                width: Math.abs(dragEnd.x - dragStart.x),
+                height: Math.abs(dragEnd.y - dragStart.y),
+              }}
+            />
+          )}
 
-        {isLoading && fileIds.length === 0 ? (
-          // Loading state
-          <div className="files-grid-loading">
-            <div className="page-loading-spinner"></div>
-          </div>
-        ) : error ? (
-          // Error state
-          <div className="files-grid-error">
-            <div>{error}</div>
-          </div>
-        ) : fileIds.length === 0 ? (
-          // Empty state
-          <div className="files-grid-empty">
-            {pageType === "search" ? (
-              !searchTags.length ? (
-                <>
-                  <MagnifyingGlassIcon className="files-grid-empty-icon" />
-                  <div>Start your search</div>
-                  <div className="files-grid-empty-text">
-                    Add tags above to find files
-                  </div>
-                </>
-              ) : searchStatus === "initial" ? (
-                <>
-                  <MagnifyingGlassIcon className="files-grid-empty-icon" />
-                  <div>
-                    Edit the search query or press the search button to start
-                  </div>
-                  <div className="files-grid-empty-text">
-                    Your search query is ready.
-                  </div>
-                </>
-              ) : searchError ? (
-                <>
-                  <ExclamationCircleIcon className="files-grid-error-icon" />
-                  <div>Error loading search results</div>
-                  <div className="files-grid-empty-text">
-                    Error: {searchError}
-                  </div>
-                </>
+          {isLoading && fileIds.length === 0 ? (
+            // Loading state
+            <div className="files-grid-loading">
+              <div className="page-loading-spinner"></div>
+            </div>
+          ) : error ? (
+            // Error state
+            <div className="files-grid-error">
+              <div>{error}</div>
+            </div>
+          ) : fileIds.length === 0 ? (
+            // Empty state
+            <div className="files-grid-empty">
+              {pageType === "search" ? (
+                !searchTags.length ? (
+                  <>
+                    <MagnifyingGlassIcon className="files-grid-empty-icon" />
+                    <div>Start your search</div>
+                    <div className="files-grid-empty-text">
+                      Add tags above to find files
+                    </div>
+                  </>
+                ) : searchStatus === "initial" ? (
+                  <>
+                    <MagnifyingGlassIcon className="files-grid-empty-icon" />
+                    <div>
+                      Edit the search query or press the search button to start
+                    </div>
+                    <div className="files-grid-empty-text">
+                      Your search query is ready.
+                    </div>
+                  </>
+                ) : searchError ? (
+                  <>
+                    <ExclamationCircleIcon className="files-grid-error-icon" />
+                    <div>Error loading search results</div>
+                    <div className="files-grid-empty-text">
+                      Error: {searchError}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <MagnifyingGlassIcon className="files-grid-empty-icon" />
+                    <div>No search results</div>
+                    <div className="files-grid-empty-text">
+                      Try different tags
+                    </div>
+                  </>
+                )
               ) : (
                 <>
-                  <MagnifyingGlassIcon className="files-grid-empty-icon" />
-                  <div>No search results</div>
-                  <div className="files-grid-empty-text">
-                    Try different tags
-                  </div>
+                  <div>No files in this page</div>
                 </>
-              )
-            ) : (
-              <>
-                <div>No files in this page</div>
-              </>
-            )}
-          </div>
-        ) : (
-          // Files grid
-          renderFiles.map((fileId, i) => (
-            <div
-              key={fileId}
-              data-file-item
-              data-file-id={fileId}
-              className={`file-item ${
-                selectedFiles.includes(fileId)
-                  ? activeFileId === fileId
-                    ? "file-item-active"
-                    : "file-item-selected"
-                  : ""
-              }`}
-              style={{
-                width: `${thumbnailSize}px`,
-                height: `${thumbnailSize}px`,
-                marginTop:
-                  useVirtualViewport && i < gridDimensions.cols
-                    ? renderView.topRows * (thumbnailSize + GAP_SIZE)
-                    : 0,
-              }}
-              onClick={(e) => handleFileClick(fileId, e)}
-              onDoubleClick={() => handleFileDoubleClick(fileId)}
-              onKeyDown={(e) => handleFileKeyDown(fileId, e)}
-              onMouseUp={(e) => {
-                if (e.button === 1) {
-                  e.preventDefault();
-                  window.open(client.getFileUrl(fileId), "_blank");
-                }
-              }}
-              onContextMenu={(e) => handleFileContextMenu(e, fileId)}
-              tabIndex={0}
-              role="button"
-              aria-selected={selectedFiles.includes(fileId)}
-              aria-label={`File ${fileId}`}
-              {...longPressHandlers}
-            >
-              <Thumbnail fileId={fileId} className="thumbnail-wrapper" />
+              )}
             </div>
-          ))
+          ) : (
+            // Files grid
+            renderFiles.map((fileId, i) => {
+              const fileIndex = useVirtualViewport
+                ? renderView.firstIndex + i
+                : i;
+              const isSelected = selectionIncludesIndex(
+                selectionIndex,
+                fileIndex,
+              );
+              return (
+                <div
+                  key={fileId}
+                  data-file-item
+                  data-file-id={fileId}
+                  className={`file-item ${
+                    isSelected
+                      ? activeFileId === fileId
+                        ? "file-item-active"
+                        : "file-item-selected"
+                      : ""
+                  }`}
+                  style={{
+                    width: `${thumbnailSize}px`,
+                    height: `${thumbnailSize}px`,
+                    marginTop:
+                      useVirtualViewport && i < gridDimensions.cols
+                        ? renderView.topRows * (thumbnailSize + GAP_SIZE)
+                        : 0,
+                  }}
+                  onClick={(e) => handleFileClick(fileId, e)}
+                  onDoubleClick={() => handleFileDoubleClick(fileId)}
+                  onKeyDown={(e) => handleFileKeyDown(fileId, e)}
+                  onMouseUp={(e) => {
+                    if (e.button === 1) {
+                      e.preventDefault();
+                      window.open(client.getFileUrl(fileId), "_blank");
+                    }
+                  }}
+                  onContextMenu={(e) => handleFileContextMenu(e, fileId)}
+                  tabIndex={0}
+                  role="button"
+                  aria-selected={isSelected}
+                  aria-label={`File ${fileId}`}
+                  {...longPressHandlers}
+                >
+                  <Thumbnail fileId={fileId} className="thumbnail-wrapper" />
+                </div>
+              );
+            })
+          )}
+          <div
+            style={{
+              pointerEvents: "none",
+              paddingBottom: useVirtualViewport
+                ? renderView.bottomRows * (thumbnailSize + GAP_SIZE)
+                : 0,
+            }}
+          ></div>
+        </ScrollView>
+
+        {selectionOverflow.above > 0 && (
+          <button
+            type="button"
+            className="page-selection-overflow-indicator page-selection-overflow-indicator-top"
+            onClick={() => scrollToSelectionEdge("top")}
+            title={`Show ${selectionOverflow.above} selected file${selectionOverflow.above === 1 ? "" : "s"} above`}
+            aria-label={`Show selected files above (${selectionOverflow.above})`}
+          >
+            <ChevronUpIcon className="page-selection-overflow-icon" />
+            <span>{selectionOverflow.above} selected</span>
+          </button>
         )}
-        <div
-          style={{
-            pointerEvents: "none",
-            paddingBottom: useVirtualViewport
-              ? renderView.bottomRows * (thumbnailSize + GAP_SIZE)
-              : 0,
-          }}
-        ></div>
-      </ScrollView>
+
+        {selectionOverflow.below > 0 && (
+          <button
+            type="button"
+            className="page-selection-overflow-indicator page-selection-overflow-indicator-bottom"
+            onClick={() => scrollToSelectionEdge("bottom")}
+            title={`Show ${selectionOverflow.below} selected file${selectionOverflow.below === 1 ? "" : "s"} below`}
+            aria-label={`Show selected files below (${selectionOverflow.below})`}
+          >
+            <span>{selectionOverflow.below} selected</span>
+            <ChevronDownIcon className="page-selection-overflow-icon" />
+          </button>
+        )}
+      </div>
 
       {modalIndex !== -1 && fileIds[modalIndex] && (
         <FileViewerModal

--- a/web/hydrui-client/src/components/widgets/PageView/index.css
+++ b/web/hydrui-client/src/components/widgets/PageView/index.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   flex-grow: 1;
   height: 100%;
+  min-height: 0;
 }
 
 .page-search-bar-container {
@@ -11,16 +12,64 @@
   position: relative;
 }
 
+.files-grid-viewport {
+  position: relative;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .files-grid {
   padding: 1rem;
   overflow: auto;
   display: grid;
   align-content: start;
-  flex-grow: 1;
+  height: 100%;
   position: relative;
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
+}
+
+.page-selection-overflow-indicator {
+  position: absolute;
+  left: 50%;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  transform: translateX(-50%);
+  border: 1px solid var(--color-blue-400);
+  border-radius: 9999px;
+  background-color: var(--color-blue-900);
+  color: var(--color-blue-100);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  line-height: 1;
+  opacity: 0.8;
+}
+
+.page-selection-overflow-indicator:hover,
+.page-selection-overflow-indicator:focus-visible {
+  opacity: 1;
+}
+
+.page-selection-overflow-indicator:focus-visible {
+  outline: 2px solid var(--color-blue-400);
+}
+
+.page-selection-overflow-indicator-top {
+  top: 0.5rem;
+}
+
+.page-selection-overflow-indicator-bottom {
+  bottom: 0.5rem;
+}
+
+.page-selection-overflow-icon {
+  width: 0.875rem;
+  height: 0.875rem;
 }
 
 .page-selection-rectangle {

--- a/web/hydrui-client/src/components/widgets/PageView/selectionNavigation.ts
+++ b/web/hydrui-client/src/components/widgets/PageView/selectionNavigation.ts
@@ -1,0 +1,180 @@
+export interface SelectionOverflow {
+  above: number;
+  below: number;
+}
+
+export interface SelectionIndex {
+  readonly length: number;
+  at(position: number): number;
+}
+
+interface SelectionGeometry {
+  selectionIndex: SelectionIndex;
+  columns: number;
+  itemSize: number;
+  gapSize: number;
+}
+
+interface SelectionViewport extends SelectionGeometry {
+  scrollTop: number;
+  viewportHeight: number;
+}
+
+const EMPTY_SELECTION_INDEX: SelectionIndex = {
+  length: 0,
+  at: () => -1,
+};
+
+const fromSortedIndices = (indices: readonly number[]): SelectionIndex => ({
+  length: indices.length,
+  at: (position) => indices[position]!,
+});
+
+export function createSelectionIndex(
+  selectedFileIds: readonly number[],
+  fileIdToIndex: ReadonlyMap<number, number>,
+  knownToBeInPageOrder = false,
+): SelectionIndex {
+  if (selectedFileIds.length === 0) return EMPTY_SELECTION_INDEX;
+
+  if (knownToBeInPageOrder) {
+    return {
+      length: selectedFileIds.length,
+      at: (position) => fileIdToIndex.get(selectedFileIds[position]!)!,
+    };
+  }
+
+  let mappedLength = 0;
+  let previousIndex = -1;
+  let isOrdered = true;
+  let everyFileIsMapped = true;
+
+  for (const fileId of selectedFileIds) {
+    const index = fileIdToIndex.get(fileId);
+    if (index === undefined) {
+      everyFileIsMapped = false;
+      continue;
+    }
+    if (index < previousIndex) isOrdered = false;
+    previousIndex = index;
+    mappedLength += 1;
+  }
+
+  if (mappedLength === 0) return EMPTY_SELECTION_INDEX;
+
+  if (everyFileIsMapped && isOrdered) {
+    return {
+      length: selectedFileIds.length,
+      at: (position) => fileIdToIndex.get(selectedFileIds[position]!)!,
+    };
+  }
+
+  const indices = new Array<number>(mappedLength);
+  let position = 0;
+  for (const fileId of selectedFileIds) {
+    const index = fileIdToIndex.get(fileId);
+    if (index !== undefined) {
+      indices[position] = index;
+      position += 1;
+    }
+  }
+  if (!isOrdered) indices.sort((a, b) => a - b);
+
+  return fromSortedIndices(indices);
+}
+
+const lowerBound = (selectionIndex: SelectionIndex, target: number) => {
+  let low = 0;
+  let high = selectionIndex.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (selectionIndex.at(middle) < target) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  return low;
+};
+
+export function selectionIncludesIndex(
+  selectionIndex: SelectionIndex,
+  index: number,
+): boolean {
+  const position = lowerBound(selectionIndex, index);
+  return (
+    position < selectionIndex.length && selectionIndex.at(position) === index
+  );
+}
+
+const getItemBounds = (
+  index: number,
+  columns: number,
+  itemSize: number,
+  gapSize: number,
+) => {
+  const row = Math.floor(index / Math.max(1, columns));
+  const top = gapSize + row * (itemSize + gapSize);
+  return { top, bottom: top + itemSize };
+};
+
+export function getSelectionOverflow({
+  selectionIndex,
+  columns,
+  itemSize,
+  gapSize,
+  scrollTop,
+  viewportHeight,
+}: SelectionViewport): SelectionOverflow {
+  const safeColumns = Math.max(1, columns);
+  const rowSize = itemSize + gapSize;
+  const viewportBottom = scrollTop + viewportHeight;
+
+  const firstRowNotAbove =
+    Math.floor((scrollTop - gapSize - itemSize) / rowSize) + 1;
+  const firstRowBelow = Math.ceil((viewportBottom - gapSize) / rowSize);
+  const above = lowerBound(
+    selectionIndex,
+    Math.max(0, firstRowNotAbove) * safeColumns,
+  );
+  const firstBelow = lowerBound(
+    selectionIndex,
+    Math.max(0, firstRowBelow) * safeColumns,
+  );
+
+  return { above, below: selectionIndex.length - firstBelow };
+}
+
+export function getSelectionScrollTarget(
+  edge: "top" | "bottom",
+  geometry: SelectionGeometry,
+  viewportHeight: number,
+): number | null {
+  if (geometry.selectionIndex.length === 0) return null;
+
+  const index = geometry.selectionIndex.at(
+    edge === "top" ? 0 : geometry.selectionIndex.length - 1,
+  );
+  const bounds = getItemBounds(
+    index,
+    geometry.columns,
+    geometry.itemSize,
+    geometry.gapSize,
+  );
+
+  return Math.max(
+    0,
+    edge === "top"
+      ? bounds.top - geometry.gapSize
+      : bounds.bottom + geometry.gapSize - viewportHeight,
+  );
+}
+
+export function getViewerExitSelection(
+  currentSelection: readonly number[],
+  lastViewedFileId: number | null,
+): number[] | null {
+  return currentSelection.length === 1 && lastViewedFileId !== null
+    ? [lastViewedFileId]
+    : null;
+}

--- a/web/hydrui-client/src/store/pageStore.ts
+++ b/web/hydrui-client/src/store/pageStore.ts
@@ -26,6 +26,10 @@ export interface VirtualPage {
   fileIds: number[];
 }
 
+interface SelectionUpdateOptions {
+  offerRestore?: boolean;
+}
+
 // Map of virtual page keys to their data
 export type VirtualPages = Record<string, VirtualPage>;
 
@@ -72,9 +76,16 @@ interface PageState extends PersistedState {
     setSelectedPageKeys: (keys: string[]) => void;
     addSelectedPageKey: (key: string) => void;
     removeSelectedPageKey: (key: string) => void;
-    setSelectedFiles: (pageKey: string, fileIds: number[]) => void;
+    setSelectedFiles: (
+      pageKey: string,
+      fileIds: number[],
+      options?: SelectionUpdateOptions,
+    ) => void;
     addSelectedFiles: (pageKey: string, fileIds: number[]) => void;
-    clearSelectedFiles: (pageKey: string) => void;
+    clearSelectedFiles: (
+      pageKey: string,
+      options?: SelectionUpdateOptions,
+    ) => void;
     setActiveFileId: (pageKey: string, fileId: number | null) => void;
     markActiveFileAsBetter: () => Promise<void>;
     archiveFiles: (fileIds: number[]) => Promise<void>;
@@ -121,6 +132,56 @@ export const usePageActions = () => usePageStore((state) => state.actions);
 export const usePageStore = create<PageState>()(
   persist(
     (set, get) => {
+      const selectionRestoreToastIds = new Map<string, string>();
+
+      const selectionsEqual = (a: number[], b: number[]) =>
+        a === b ||
+        (a.length === b.length && a.every((fileId, i) => fileId === b[i]));
+
+      const offerSelectionRestore = (
+        pageKey: string,
+        previousFileIds: number[],
+        previousActiveFileId: number | null,
+        wasCleared: boolean,
+      ) => {
+        const { addToast, removeToast } = useToastStore.getState().actions;
+        const previousToastId = selectionRestoreToastIds.get(pageKey);
+        if (previousToastId) removeToast(previousToastId);
+
+        let toastId = "";
+        const dismiss = () => {
+          removeToast(toastId);
+          if (selectionRestoreToastIds.get(pageKey) === toastId) {
+            selectionRestoreToastIds.delete(pageKey);
+          }
+        };
+        toastId = addToast(
+          `${wasCleared ? "Cleared" : "Replaced"} selection of ${previousFileIds.length} files.`,
+          "info",
+          {
+            actions: [
+              {
+                label: "Restore",
+                variant: "primary",
+                callback: () => {
+                  get().actions.setSelectedFiles(pageKey, previousFileIds, {
+                    offerRestore: false,
+                  });
+                  get().actions.setActiveFileId(pageKey, previousActiveFileId);
+                  dismiss();
+                },
+              },
+              {
+                label: "Dismiss",
+                variant: "muted",
+                callback: dismiss,
+              },
+            ],
+          },
+        );
+        selectionRestoreToastIds.set(pageKey, toastId);
+      };
+
       const getRealizedFile = async (fileId: number) => {
         const { loadedFiles, fileIdToIndex, metadataLoadController } = get();
         if (metadataLoadController) {
@@ -814,7 +875,21 @@ export const usePageStore = create<PageState>()(
             }));
           },
 
-          setSelectedFiles: (pageKey: string, fileIds: number[]) => {
+          setSelectedFiles: (
+            pageKey: string,
+            fileIds: number[],
+            { offerRestore = true } = {},
+          ) => {
+            const previousFileIds = get().selectedFilesByPage[pageKey] || [];
+            if (selectionsEqual(previousFileIds, fileIds)) return;
+            if (offerRestore && previousFileIds.length > 10) {
+              offerSelectionRestore(
+                pageKey,
+                previousFileIds,
+                get().activeFileByPage[pageKey] ?? null,
+                fileIds.length === 0,
+              );
+            }
             set((state) => ({
               selectedFilesByPage: {
                 ...state.selectedFilesByPage,
@@ -837,7 +912,20 @@ export const usePageStore = create<PageState>()(
             }));
           },
 
-          clearSelectedFiles: (pageKey: string) => {
+          clearSelectedFiles: (
+            pageKey: string,
+            { offerRestore = true } = {},
+          ) => {
+            const previousFileIds = get().selectedFilesByPage[pageKey] || [];
+            if (previousFileIds.length === 0) return;
+            if (offerRestore && previousFileIds.length > 10) {
+              offerSelectionRestore(
+                pageKey,
+                previousFileIds,
+                get().activeFileByPage[pageKey] ?? null,
+                true,
+              );
+            }
             set((state) => {
               const newSelectedFiles = { ...state.selectedFilesByPage };
               delete newSelectedFiles[pageKey];


### PR DESCRIPTION
This PR attempts to improve on the usability of selections in Hydrui in several ways:

- Firstly, when you clear or replace a selection of more than 10 items, a toast pops up allowing you to restore it. This is probably sometimes annoying, but is very useful in the case where you accidentally clear your selection while trying to select a bunch of specific files at once.

- Secondly, now Hydrui has buttons that show up indicating when there are selected items above and/or below the current viewport, which you can click to go to the first/last selected item.

- Thirdly, when exiting the file viewer, if you only had one file selected, then the selected and active file is moved to whatever you exited the file viewer on. The file focused in the file viewer is still the one you started on, so it shouldn't be too hard to see it.

Some of these may not always be desirable in all situations, so it might warrant adding more options. However, for now, I'm just going to enable them always and hope for the best.